### PR TITLE
More performance fixes

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -83,12 +83,6 @@ func BenchmarkHugePayload(b *testing.B) {
 				"brand":              "Impression of Acqua Di Gio",
 				"category":           "fragrances",
 				"thumbnail":          "https://dummyjson.com/image/i/products/11/thumbnail.jpg",
-				"images": []string{
-					"https://dummyjson.com/image/i/products/11/1.jpg",
-					"https://dummyjson.com/image/i/products/11/2.jpg",
-					"https://dummyjson.com/image/i/products/11/3.jpg",
-					"https://dummyjson.com/image/i/products/11/thumbnail.jpg",
-				},
 			}).Info("fetched details")
 		}
 	})
@@ -193,12 +187,6 @@ func BenchmarkHugePayload_WithColor(b *testing.B) {
 				"brand":              "Impression of Acqua Di Gio",
 				"category":           "fragrances",
 				"thumbnail":          "https://dummyjson.com/image/i/products/11/thumbnail.jpg",
-				"images": []string{
-					"https://dummyjson.com/image/i/products/11/1.jpg",
-					"https://dummyjson.com/image/i/products/11/2.jpg",
-					"https://dummyjson.com/image/i/products/11/3.jpg",
-					"https://dummyjson.com/image/i/products/11/thumbnail.jpg",
-				},
 			}).Info("fetched details")
 		}
 	})

--- a/examples/main.go
+++ b/examples/main.go
@@ -9,6 +9,7 @@ import (
 
 func main() {
 	logger := logf.New()
+
 	// Basic log.
 	logger.Info("starting app")
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -34,7 +34,7 @@ func main() {
 	logger.SetTimestampFormat(time.RFC3339Nano)
 
 	// Create a logger and add fields which will be logged in every line.
-	requestLogger := logger.WithFields(logf.Fields{"request_id": "3MG91VKP", "ip": "1.1.1.1", "method": "GET"})
+	requestLogger := logger.WithFields(logf.Fields{"request_id": "3MG91VKP", "ip": "1.1.1.1", "method": "method=GET"})
 	requestLogger.Info("request success")
 	requestLogger.Warn("this isn't supposed to happen")
 

--- a/field_logger.go
+++ b/field_logger.go
@@ -1,0 +1,25 @@
+package logf
+
+type FieldLogger struct {
+	fields Fields
+	logger *Logger
+}
+
+func (l *FieldLogger) Debug(msg string) {
+	l.logger.handleLog(msg, DebugLevel, l.fields)
+}
+
+// Info emits a info log line.
+func (l *FieldLogger) Info(msg string) {
+	l.logger.handleLog(msg, InfoLevel, l.fields)
+}
+
+// Warn emits a warning log line.
+func (l *FieldLogger) Warn(msg string) {
+	l.logger.handleLog(msg, WarnLevel, l.fields)
+}
+
+// Error emits an error log line.
+func (l *FieldLogger) Error(msg string) {
+	l.logger.handleLog(msg, ErrorLevel, l.fields)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,9 @@ module github.com/mr-karan/logf
 
 go 1.18
 
-require (
-	github.com/fatih/color v1.13.0
-	github.com/stretchr/testify v1.2.2
-)
+require github.com/stretchr/testify v1.2.2
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/mattn/go-colorable v0.1.9 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,17 +1,6 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
-github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
-github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
-github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/log_test.go
+++ b/log_test.go
@@ -54,7 +54,7 @@ func TestLogFormat(t *testing.T) {
 
 	// Info log.
 	l.Info("hello world")
-	assert.Contains(t, buf.String(), "level=info message=hello world", "info log")
+	assert.Contains(t, buf.String(), `level=info message="hello world"`, "info log")
 	buf.Reset()
 
 	// Log with field.
@@ -64,7 +64,7 @@ func TestLogFormat(t *testing.T) {
 	fl := l.WithFields(fields)
 	assert.Equal(t, fl.fields, fields)
 	fl.Warn("testing fields")
-	assert.Contains(t, buf.String(), "level=warn message=testing fields stack=testing", "warning log")
+	assert.Contains(t, buf.String(), `level=warn message="testing fields" stack=testing`, "warning log")
 	buf.Reset()
 
 	// Log with error.
@@ -73,7 +73,7 @@ func TestLogFormat(t *testing.T) {
 	// Check if error key exists.
 	assert.Equal(t, el.fields["error"], fakeErr.Error())
 	el.Error("testing error")
-	assert.Contains(t, buf.String(), "level=error message=testing error error=this is a fake error", "error log")
+	assert.Contains(t, buf.String(), `level=error message="testing error" error="this is a fake error"`, "error log")
 	buf.Reset()
 }
 


### PR DESCRIPTION
- Remove a single buffer from logger and use a buffer pool.
- Add a new logger called field logger which contains it's own fields, so it's not necessary to lock the whole logger anymore.
- Adds escaping before writing to the buffer.

This is the new benchmarks:

![2022-06-30_17-16](https://user-images.githubusercontent.com/10434498/176670332-fd721027-9ed9-43d7-bdb5-66b30ddbd39b.png)

